### PR TITLE
Play nice with other mods' master server overrides

### DIFF
--- a/BeatTogether/Models/TemporaryServerDetails.cs
+++ b/BeatTogether/Models/TemporaryServerDetails.cs
@@ -1,0 +1,14 @@
+﻿namespace BeatTogether.Models
+{
+    public class TemporaryServerDetails : ServerDetails
+    {
+        public TemporaryServerDetails(DnsEndPoint masterServerEndPoint)
+        {
+            ServerName = masterServerEndPoint.hostName;
+            HostName = masterServerEndPoint.hostName;
+            Port = masterServerEndPoint.port;
+            StatusUri = string.Empty;
+            MaxPartySize = IsOfficial ? 5 : 128;
+        }
+    }
+}

--- a/BeatTogether/Registries/ServerDetailsRegistry.cs
+++ b/BeatTogether/Registries/ServerDetailsRegistry.cs
@@ -8,7 +8,8 @@ namespace BeatTogether.Registries
     public class ServerDetailsRegistry
     {
         public ServerDetails SelectedServer
-            => Servers.FirstOrDefault(details => details.ServerName == _config.SelectedServer)
+            => TemporarySelectedServer
+            ?? Servers.FirstOrDefault(details => details.ServerName == _config.SelectedServer)
             ?? Servers.FirstOrDefault(details => details.ServerName == Config.BeatTogetherServerName);
 
         public IReadOnlyList<ServerDetails> Servers
@@ -20,6 +21,8 @@ namespace BeatTogether.Registries
         {
             ServerName = Config.OfficialServerName
         };
+
+        public TemporaryServerDetails? TemporarySelectedServer { get; private set; }
 
         internal ServerDetailsRegistry(
             Config config)
@@ -35,6 +38,16 @@ namespace BeatTogether.Registries
         }
 
         public void SetSelectedServer(ServerDetails server)
-            => _config.SelectedServer = server.ServerName;
+        {
+            if (server is TemporaryServerDetails tmpServer)
+            {
+                TemporarySelectedServer = tmpServer;
+            }
+            else
+            {
+                _config.SelectedServer = server.ServerName;
+                TemporarySelectedServer = null;
+            }
+        }
     }
 }

--- a/BeatTogether/UI/ServerSelectionController.cs
+++ b/BeatTogether/UI/ServerSelectionController.cs
@@ -12,24 +12,33 @@ using SiraUtil.Affinity;
 using SiraUtil.Logging;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using IPA.Config.Stores.Attributes;
+using JetBrains.Annotations;
 using UnityEngine;
 using Zenject;
 
 namespace BeatTogether.UI
 {
-    internal class ServerSelectionController : IInitializable, IAffinity
+    internal class ServerSelectionController : IInitializable, IAffinity, INotifyPropertyChanged
     {
         public const string ResourcePath = "BeatTogether.UI.ServerSelectionController.bsml";
 
         private Action<FlowCoordinator, bool, bool, bool> _didActivate
             = MethodAccessor<FlowCoordinator, Action<FlowCoordinator, bool, bool, bool>>
                 .GetDelegate("DidActivate");
+
         private Action<FlowCoordinator, bool, bool> _didDeactivate
             = MethodAccessor<FlowCoordinator, Action<FlowCoordinator, bool, bool>>
                 .GetDelegate("DidDeactivate");
-        private Action<FlowCoordinator, ViewController, Action, ViewController.AnimationType, ViewController.AnimationDirection> _replaceTopScreenViewController
-            = MethodAccessor<FlowCoordinator, Action<FlowCoordinator, ViewController, Action, ViewController.AnimationType, ViewController.AnimationDirection>>
+
+        private Action<FlowCoordinator, ViewController, Action, ViewController.AnimationType,
+            ViewController.AnimationDirection> _replaceTopScreenViewController
+            = MethodAccessor<FlowCoordinator, Action<FlowCoordinator, ViewController, Action,
+                    ViewController.AnimationType, ViewController.AnimationDirection>>
                 .GetDelegate("ReplaceTopViewController");
 
         private FloatingScreen _screen = null!;
@@ -40,8 +49,7 @@ namespace BeatTogether.UI
         private readonly ServerDetailsRegistry _serverRegistry;
         private readonly SiraLog _logger;
 
-        [UIComponent("server-list")]
-        private ListSetting _serverList = null!;
+        [UIComponent("server-list")] private ListSetting _serverList = null!;
 
         [UIValue("server")]
         private ServerDetails _serverValue
@@ -50,8 +58,7 @@ namespace BeatTogether.UI
             set => ServerChanged(value);
         }
 
-        [UIValue("server-options")]
-        private List<object> _serverOptions;
+        [UIValue("server-options")] private List<object> _serverOptions;
 
         internal ServerSelectionController(
             MultiplayerModeSelectionFlowCoordinator modeSelectionFlow,
@@ -71,8 +78,10 @@ namespace BeatTogether.UI
 
         public void Initialize()
         {
-            _screen = FloatingScreen.CreateFloatingScreen(new Vector2(90, 90), false, new Vector3(0, 3f, 4.35f), new Quaternion(0,0,0,0));
-            BSMLParser.instance.Parse(Utilities.GetResourceContent(Assembly.GetExecutingAssembly(), ResourcePath), _screen.gameObject, this);
+            _screen = FloatingScreen.CreateFloatingScreen(new Vector2(90, 90), false, new Vector3(0, 3f, 4.35f),
+                new Quaternion(0, 0, 0, 0));
+            BSMLParser.instance.Parse(Utilities.GetResourceContent(Assembly.GetExecutingAssembly(), ResourcePath),
+                _screen.gameObject, this);
             (_serverList.gameObject.transform.GetChild(1) as RectTransform)!.sizeDelta = new Vector2(60, 0);
             _screen.GetComponent<CurvedCanvasSettings>().SetRadius(140);
             _screen.gameObject.SetActive(false);
@@ -80,6 +89,9 @@ namespace BeatTogether.UI
 
         private void ServerChanged(ServerDetails server)
         {
+            if (server is TemporaryServerDetails)
+                return;
+            
             _logger.Debug($"Server changed to '{server.ServerName}': '{server.HostName}:{server.Port}'");
             _serverRegistry.SetSelectedServer(server);
             if (server.IsOfficial)
@@ -87,24 +99,88 @@ namespace BeatTogether.UI
             else
                 _networkConfig.UseMasterServer(server.EndPoint!, server.StatusUri, server.MaxPartySize);
 
+            SyncTemporarySelectedServer();
+            
             _serverList.interactable = false;
             _didDeactivate(_modeSelectionFlow, false, false);
             _didActivate(_modeSelectionFlow, false, true, false);
-            _replaceTopScreenViewController(_modeSelectionFlow, _joiningLobbyView, HandleTransitionFinished, ViewController.AnimationType.None, ViewController.AnimationDirection.Vertical);
+            _replaceTopScreenViewController(_modeSelectionFlow, _joiningLobbyView, HandleTransitionFinished,
+                ViewController.AnimationType.None, ViewController.AnimationDirection.Vertical);
         }
 
-        private void HandleTransitionFinished() { }
-            //=> _serverList.interactable = true;
+        private void HandleTransitionFinished()
+        {
+        }
+        //=> _serverList.interactable = true;
 
         [AffinityPrefix]
         [AffinityPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "DidActivate")]
         private void DidActivate()
         {
-            if (_serverRegistry.SelectedServer.IsOfficial)
-                _networkConfig.UseOfficialServer();
+            SyncSelectedServer();
+        }
+
+        private void SyncSelectedServer()
+        {
+            var didChangeSelection = false;
+
+            if (_networkConfig.MasterServerEndPoint is not null)
+            {
+                // Master server is being patched by MpCore, sync our selection
+                var knownServer = _serverRegistry.Servers.FirstOrDefault(
+                    sd => sd.EndPoint?.Equals(_networkConfig.MasterServerEndPoint) ?? false
+                );
+
+                if (knownServer != _serverRegistry.SelectedServer)
+                {
+                    _logger.Info("Changing server selection from patch sync!");
+                    _serverRegistry.SetSelectedServer(knownServer
+                                                      ?? new TemporaryServerDetails(_networkConfig.MasterServerEndPoint));
+                    didChangeSelection = true;
+                }
+            }
             else
-                _networkConfig.UseMasterServer(_serverRegistry.SelectedServer.EndPoint!, _serverRegistry.SelectedServer.StatusUri, _serverRegistry.SelectedServer.MaxPartySize);
+            {
+                // No one is patching the master server, restore our selected server from config
+                if (_serverRegistry.SelectedServer.IsOfficial)
+                    _networkConfig.UseOfficialServer();
+                else
+                    _networkConfig.UseMasterServer(_serverRegistry.SelectedServer.EndPoint!,
+                        _serverRegistry.SelectedServer.StatusUri, _serverRegistry.SelectedServer.MaxPartySize);
+            }
+            
+            // Sync UI
+            if (didChangeSelection)
+            {
+                SyncTemporarySelectedServer();
+                OnPropertyChanged(nameof(_serverValue)); // for BSML binding
+            }
+
             _screen.gameObject.SetActive(true);
+        }
+
+        private void SyncTemporarySelectedServer()
+        {
+            var didChange = false;
+            
+            if (_serverRegistry.TemporarySelectedServer is not null)
+            {
+                var temporaryServer = _serverRegistry.TemporarySelectedServer!;
+
+                if (!_serverOptions.Contains(temporaryServer))
+                {
+                    _serverOptions.Add(temporaryServer);
+                    didChange = true;
+                }
+            }
+            else
+            {
+                if (_serverOptions.RemoveAll(so => so is TemporaryServerDetails) > 0)
+                    didChange = true;
+            }
+
+            if (didChange)
+                OnPropertyChanged(nameof(_serverOptions)); // for BSML binding
         }
 
         [AffinityPrefix]
@@ -118,11 +194,13 @@ namespace BeatTogether.UI
 
         [AffinityPrefix]
         [AffinityPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "TopViewControllerWillChange")]
-        private bool TopViewControllerWillChange(ViewController oldViewController, ViewController newViewController, ViewController.AnimationType animationType)
+        private bool TopViewControllerWillChange(ViewController oldViewController, ViewController newViewController,
+            ViewController.AnimationType animationType)
         {
             if (newViewController is JoiningLobbyViewController)
                 _serverList.interactable = oldViewController is MultiplayerModeSelectionViewController;
-            if (newViewController is MultiplayerModeSelectionViewController && oldViewController is JoiningLobbyViewController)
+            if (newViewController is MultiplayerModeSelectionViewController &&
+                oldViewController is JoiningLobbyViewController)
                 _serverList.interactable = true;
             if (newViewController is JoiningLobbyViewController && animationType == ViewController.AnimationType.None)
                 return false;
@@ -130,8 +208,10 @@ namespace BeatTogether.UI
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(ViewControllerTransitionHelpers), nameof(ViewControllerTransitionHelpers.DoPresentTransition))]
-        private void DoPresentTransition(ViewController toPresentViewController, ViewController toDismissViewController, ref ViewController.AnimationDirection animationDirection)
+        [AffinityPatch(typeof(ViewControllerTransitionHelpers),
+            nameof(ViewControllerTransitionHelpers.DoPresentTransition))]
+        private void DoPresentTransition(ViewController toPresentViewController, ViewController toDismissViewController,
+            ref ViewController.AnimationDirection animationDirection)
         {
             if (toDismissViewController is JoiningLobbyViewController)
                 animationDirection = ViewController.AnimationDirection.Vertical;
@@ -149,5 +229,17 @@ namespace BeatTogether.UI
         [AffinityPatch(typeof(FlowCoordinator), "SetGlobalUserInteraction")]
         private void SetGlobalUserInteraction(bool value)
             => _serverList.interactable = value;
+
+        #region INotifyPropertyChanged
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
This PR fixes some issues that prevent other mods like the Server Browser from overriding the master server properly via MultiplayerCore.

The BT plugin will now check whether MultiplayerCore is already overriding, and if so, select that server as well so it's visible. If the server isn't known, a "temporary" option is selected.

This fixes two things in particular:
 - BT will not apply overrides for its own selected server every time mode selection opens (this breaks server browser settings)
 - If there's an external override like from the server browser, it's actually visible on the UI

Temporary options go away when you select another server and they aren't persisted to config.

Example scenario: Connecting to a third party server via the Server Browser that's not in my BT config will now show that in the selector temporarily:

![image](https://user-images.githubusercontent.com/6772638/160245093-d41aaa8d-91e8-4910-a390-283808ae2b4e.png)